### PR TITLE
Removed promisify from the existing repositories

### DIFF
--- a/src/repositories/TokenRepository.js
+++ b/src/repositories/TokenRepository.js
@@ -1,15 +1,8 @@
-const { promisify } = require('util');
 const config = require('../config');
 
 class TokenRepository {
   constructor({ redisClient }) {
     this.redisClient = redisClient;
-    this.set = promisify(redisClient.set).bind(redisClient);
-    this.get = promisify(redisClient.get).bind(redisClient);
-    this.del = promisify(redisClient.del).bind(redisClient);
-    this.sadd = promisify(redisClient.sadd).bind(redisClient);
-    this.smembers = promisify(redisClient.smembers).bind(redisClient);
-    this.expire = promisify(redisClient.expire).bind(redisClient);
   }
 
   constructRefreshTokenKey(userId, tokenId) {

--- a/src/repositories/UserRepository.js
+++ b/src/repositories/UserRepository.js
@@ -1,4 +1,3 @@
-const { promisify } = require('util');
 // const logger = require('../loaders/logger');
 
 class UserRepository {
@@ -7,9 +6,6 @@ class UserRepository {
     this.redisClient = redisClient;
     // logger.debug(redisClient);
     // console.log('redis client from user repo : ', redisClient);
-    this.del = promisify(redisClient.del).bind(redisClient);
-    this.set = promisify(redisClient.set).bind(redisClient);
-    this.get = promisify(redisClient.get).bind(redisClient);
   }
 
   toPersistance(user) {


### PR DESCRIPTION
Updated redis adapter in the previous commit which now supports promises. Hence removing promisify which is not required anymore. 